### PR TITLE
feat: path-scoped routing rules (serve, upstream, proxy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ hrserve is a hot-reload development server with an unusual architecture: **the b
 ## File map
 
 - `lib/hrserve.ts` — the core. `createServer()` sets up per-MIME-type patchers, the CDP session, request routing, and file watchers. Public API: `serve()`, `close()`, events `patch` / `new-resource`.
-- `lib/resolve-request.ts` — pure-ish mapping from a request URL to a decision: serve a file, fall back to serve-handler (listing/404), 404, or pass through to the network. All URL/path edge cases live here; it is unit-tested.
+- `lib/rules.ts` — the routing rule table: user-facing `Rule` types (`serve` / `upstream` / `proxy`), normalization (defaults, validation) and glob matching via picomatch. Rules are ordered, first match wins, matched against the path relative to the base URL.
+- `lib/resolve-request.ts` — pure-ish mapping from a request URL to a decision: serve a file, proxy, fall back to serve-handler (listing/404), 404, or pass through to the network. All URL/path edge cases live here; it is unit-tested.
 - `lib/serve-directory.ts` — bridges serve-handler (which expects Node `IncomingMessage`/`ServerResponse`) onto a Playwright `Route` with mock request/response objects. Used for directory listings and 404 pages.
 - `lib/reload-image.ts` — an in-page function (run via `page.evaluate`) that cache-busts every reference to a changed image: `<img>`, `srcset`, CSS rules, inline styles, SVG `<image>`, favicons, etc.
 - `lib/types.d.ts` — hand-written declaration for `csstree-validator` (no upstream types).
@@ -39,6 +40,7 @@ The `patch` event is emitted **once per file change by the watcher callback** in
 - **URL matching must be segment-aware.** `resolve-request.ts` compares parsed origin + pathname, not string prefixes — `http://localhost:3000` must not capture `http://localhost:30001`, and base `/app` must not capture `/apple`. Paths are percent-decoded before hitting the filesystem, with a containment check because encoded slashes (`%2f`) survive URL normalization and could otherwise escape `dir`.
 - **serve-handler's response contract is messy.** It both assigns `response.statusCode` directly *and* calls `writeHead()`, and mixes `setHeader()` with `writeHead()` headers. The mock in `serve-directory.ts` keeps a real `statusCode` property and merges (never replaces) headers. It receives the raw **URL path** (e.g. `/sub/`), not a filesystem path — serve-handler does its own decoding.
 - **mime-db has flip-flopped on `.js`** between `application/javascript` and `text/javascript`; the JS patcher is registered under both keys.
+- **Proxying must use `route.fetch()` + `route.fulfill()`, never `route.continue({ url })`.** Playwright accepts a cross-origin `continue({ url })` without complaint, but the browser then applies CORS to the response and the page gets "Failed to fetch" — verified, and the reason the proxy rule is implemented the way it is. Fetching from Node and fulfilling locally keeps the response same-origin from the page's perspective.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Starts serving files and watching for changes. Resolves with the Playwright `Pag
 
 **Parameters:**
 - `options.url`: The base URL to serve
-- `options.dir`: Directory to serve files from
+- `options.dir`: Directory to serve files from (optional when every rule sets its own `dir`)
+- `options.rules`: Ordered routing rules — see [Routing rules](#routing-rules)
 - `options.width`: Browser window width (default: 1280)
 - `options.height`: Browser window height (default: 720)
 - `options.verbose`: Log request routing and CDP events (default: false)
@@ -80,6 +81,33 @@ Listen for server events.
 **Events:**
 - `'patch'`: Emitted once per file change. Handler receives `{ fileName, url, mimeType }`
 - `'new-resource'`: Emitted when a served file starts being watched. Handler receives `{ url, mimeType }`
+
+## Routing rules
+
+By default every `GET` under the base URL is served from `dir`. Pass `rules` to mix local files with real network traffic — an ordered list, **first match wins**:
+
+```javascript
+await server.serve({
+  url: "https://app.example.com/",
+  dir: "./dist",
+  rules: [
+    { match: "/assets/**", action: "serve", dir: "./dist/assets" },
+    { match: "/api/**", action: "proxy", target: "https://staging-api.example.com" },
+    { match: "/health", action: "upstream" },
+    { match: "**", action: "serve" },
+  ],
+});
+```
+
+`match` is a glob ([picomatch](https://github.com/micromatch/picomatch) syntax) tested against the request path **relative to the base URL**, so with a base of `https://app.example.com/` the rule `/api/**` matches `https://app.example.com/api/users`. It defaults to `**`. An optional `methods: ["POST"]` narrows a rule to specific HTTP methods.
+
+**Actions:**
+
+- `serve` — answer from `dir` (falling back to a directory listing or 404 page). Only `GET`/`HEAD`; other methods go to the network. Served files are watched and patched as usual. `dir` defaults to the top-level `dir`, and mirrors the URL space beneath it.
+- `upstream` — let the request through to the real network, untouched.
+- `proxy` — send the request to `target`, preserving path, query, method, headers and body. hrserve performs this request itself and returns the result as if it came from the page's own origin, **so the page is not subject to CORS**. A path prefix on the target is kept: target `https://example.com/v2` + request `/api/users` → `https://example.com/v2/api/users`. If the target is unreachable the page gets a 502.
+
+Requests matching **no** rule go to the network, so a rule list without a `**` entry is an overlay rather than a full server.
 
 ### In-page events
 

--- a/lib/hrserve.ts
+++ b/lib/hrserve.ts
@@ -4,12 +4,24 @@ import chokidar from "chokidar";
 import { validate } from "csstree-validator";
 import type { Browser, CDPSession, Page, Request, Route } from "playwright";
 import { IMAGE_MIME_TYPES, reloadImage } from "./reload-image";
-import { resolveRequest } from "./resolve-request";
+import { type ResolveConfig, normalizeBaseUrl, resolveRequest } from "./resolve-request";
+import { type Rule, normalizeRules } from "./rules";
 import { serveDirectoryListing } from "./serve-directory";
+
+export type { Rule, ServeRule, UpstreamRule, ProxyRule } from "./rules";
 
 interface ServeOptions {
   url: string;
-  dir: string;
+  /**
+   * Directory to serve from. Optional when every rule carries its own `dir`.
+   * With no `rules`, everything under `url` is served from here.
+   */
+  dir?: string;
+  /**
+   * Ordered routing rules, first match wins. Paths are matched relative to the
+   * base `url` (e.g. "/api/**"). Requests matching no rule go to the network.
+   */
+  rules?: Rule[];
   width?: number;
   height?: number;
   /** Log request routing and CDP events. */
@@ -154,10 +166,15 @@ export function createServer(browser: Browser): HRServer {
 
   // Main server functionality
   server.serve = async (options: ServeOptions): Promise<Page> => {
-    const { url: targetUrl, dir, width = 1280, height = 720, verbose = false } = options;
+    const { url: targetUrl, dir, rules, width = 1280, height = 720, verbose = false } = options;
     if (verbose) {
       log = (...args: unknown[]) => console.log(...args);
     }
+
+    const routeConfig: ResolveConfig = {
+      baseUrl: normalizeBaseUrl(targetUrl),
+      rules: normalizeRules(rules, dir),
+    };
 
     const context = await browser.newContext({
       viewport: { width, height },
@@ -224,23 +241,32 @@ export function createServer(browser: Browser): HRServer {
 
     // Use Playwright's route API for request interception
     await page.route("**/*", async (route: Route, request: Request) => {
-      if (request.method() !== "GET") {
-        return route.continue();
-      }
-
       const url = request.url();
-      const resolved = await resolveRequest(dir, targetUrl, url);
-      log("request", url, "->", resolved.kind);
+      const resolved = await resolveRequest(routeConfig, url, request.method());
+      log("request", request.method(), url, "->", resolved.kind);
 
       switch (resolved.kind) {
         case "pass":
           return route.continue();
+        case "proxy": {
+          // Fetch from Node rather than route.continue({ url }): continuing to
+          // another origin makes the browser apply CORS to the response, which
+          // defeats the point. Fetching here and fulfilling locally keeps the
+          // response same-origin as far as the page is concerned.
+          try {
+            const response = await route.fetch({ url: resolved.target });
+            return await route.fulfill({ response });
+          } catch (e) {
+            console.warn("Proxy request failed", resolved.target, e);
+            return route.fulfill({ status: 502, body: "hrserve: proxy request failed" });
+          }
+        }
         case "forbidden":
         case "unknown-type":
           return route.fulfill({ status: 404 });
         case "fallback":
           // serve-handler renders the directory listing / 404 page
-          return serveDirectoryListing(dir, route, resolved.urlPath);
+          return serveDirectoryListing(resolved.dir, route, resolved.urlPath);
         case "file": {
           const { filePath, mimeType } = resolved;
           const body = await fs.readFile(filePath);

--- a/lib/resolve-request.ts
+++ b/lib/resolve-request.ts
@@ -1,18 +1,27 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import mime from "mime-types";
+import { type NormalizedRule, buildProxyTarget, matchRule } from "./rules";
 
 export type ResolvedRequest =
-  /** Request is not under the served base URL; let it through to the network. */
+  /** Not ours (outside the base URL, or no rule matched): let it hit the network. */
   | { kind: "pass" }
+  /** Send the request to another origin with a rewritten URL. */
+  | { kind: "proxy"; target: string }
   /** Request tried to escape the served directory (or has malformed encoding). */
   | { kind: "forbidden" }
   /** File exists but its MIME type is unknown. */
   | { kind: "unknown-type"; filePath: string }
   /** Missing file or directory without index.html; `urlPath` is the raw URL path
    * (relative to the base URL) to hand to serve-handler for a listing / 404 page. */
-  | { kind: "fallback"; urlPath: string }
+  | { kind: "fallback"; urlPath: string; dir: string }
   | { kind: "file"; filePath: string; mimeType: string };
+
+export interface ResolveConfig {
+  /** Base URL, normalized to end with "/". */
+  baseUrl: string;
+  rules: NormalizedRule[];
+}
 
 /** Ensure the base URL ends with "/" so prefix matching can't cross a path segment
  * (e.g. base "http://host/app" must not match "http://host/apple"). */
@@ -20,23 +29,26 @@ export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 }
 
+/** Methods for which serving a file from disk makes sense. */
+const FILE_METHODS = new Set(["GET", "HEAD"]);
+
 /**
- * Map a request URL onto the served directory.
+ * Map a request URL onto a routing decision.
  *
  * Matching compares origin and path segments via the URL parser rather than raw
  * string prefixes, so "http://localhost:3000" does not capture requests to
  * "http://localhost:30001" and query strings are ignored.
  */
 export async function resolveRequest(
-  dir: string,
-  baseUrl: string,
-  requestUrl: string
+  config: ResolveConfig,
+  requestUrl: string,
+  method = "GET"
 ): Promise<ResolvedRequest> {
   let requested: URL;
   let base: URL;
   try {
     requested = new URL(requestUrl);
-    base = new URL(normalizeBaseUrl(baseUrl));
+    base = new URL(normalizeBaseUrl(config.baseUrl));
   } catch {
     return { kind: "pass" };
   }
@@ -48,12 +60,38 @@ export async function resolveRequest(
     return { kind: "pass" };
   }
 
-  // Raw URL path relative to the base, with a leading "/" (what serve-handler expects).
+  // Raw URL path relative to the base, with a leading "/" (what rules match against
+  // and what serve-handler expects).
   const urlPath = requested.pathname.slice(basePath.length - 1) || "/";
+
+  const rule = matchRule(config.rules, urlPath, method);
+  if (!rule) {
+    return { kind: "pass" };
+  }
+
+  switch (rule.action) {
+    case "upstream":
+      return { kind: "pass" };
+
+    case "proxy":
+      return {
+        kind: "proxy",
+        target: buildProxyTarget(rule.target as string, urlPath, requested.search),
+      };
+
+    default:
+      break;
+  }
+
+  // action: "serve"
+  if (!FILE_METHODS.has(method.toUpperCase())) {
+    return { kind: "pass" };
+  }
+  const dir = rule.dir as string;
 
   let relativePath: string;
   try {
-    relativePath = decodeURIComponent(requested.pathname.slice(basePath.length));
+    relativePath = decodeURIComponent(urlPath.slice(1));
   } catch {
     return { kind: "forbidden" };
   }
@@ -69,7 +107,7 @@ export async function resolveRequest(
 
   const stat = await fs.stat(filePath).catch(() => null);
   if (!stat) {
-    return { kind: "fallback", urlPath };
+    return { kind: "fallback", urlPath, dir };
   }
 
   let finalPath = filePath;
@@ -77,7 +115,7 @@ export async function resolveRequest(
     const indexPath = path.join(filePath, "index.html");
     const indexStat = await fs.stat(indexPath).catch(() => null);
     if (!indexStat?.isFile()) {
-      return { kind: "fallback", urlPath };
+      return { kind: "fallback", urlPath, dir };
     }
     finalPath = indexPath;
   }

--- a/lib/rules.ts
+++ b/lib/rules.ts
@@ -1,0 +1,108 @@
+import picomatch from "picomatch";
+
+/** Serve the request from a local directory (the default hrserve behaviour). */
+export interface ServeRule {
+  /** Glob matched against the request path relative to the base URL, e.g. "/assets/**". Defaults to "**". */
+  match?: string;
+  /** HTTP methods this rule applies to. Defaults to every method. */
+  methods?: string[];
+  action: "serve";
+  /** Directory to serve from. Defaults to the top-level `dir` passed to serve(). */
+  dir?: string;
+}
+
+/** Let the request go to the network untouched. */
+export interface UpstreamRule {
+  match?: string;
+  methods?: string[];
+  action: "upstream";
+}
+
+/**
+ * Send the request to a different origin. Unlike `upstream`, the URL is
+ * rewritten, so the page can talk to another backend without CORS: as far as
+ * the page is concerned the request never left its own origin.
+ */
+export interface ProxyRule {
+  match?: string;
+  methods?: string[];
+  action: "proxy";
+  /** Target origin, optionally with a path prefix, e.g. "https://staging.example.com/v2". */
+  target: string;
+}
+
+export type Rule = ServeRule | UpstreamRule | ProxyRule;
+
+export interface NormalizedRule {
+  match: string;
+  methods?: string[];
+  action: Rule["action"];
+  dir?: string;
+  target?: string;
+  isMatch(urlPath: string): boolean;
+}
+
+/**
+ * Turn the user-facing rule list into matchers, filling in defaults.
+ *
+ * With no rules, hrserve behaves as it always has: everything under the base
+ * URL is served from `defaultDir`.
+ */
+export function normalizeRules(rules: Rule[] | undefined, defaultDir?: string): NormalizedRule[] {
+  const source: Rule[] = rules?.length ? rules : [{ action: "serve" }];
+
+  return source.map((rule, index) => {
+    const match = rule.match ?? "**";
+    const dir = rule.action === "serve" ? (rule.dir ?? defaultDir) : undefined;
+
+    if (rule.action === "serve" && !dir) {
+      throw new Error(
+        `Rule ${index} ("${match}") has action "serve" but no directory: ` +
+          "set `dir` on the rule or pass `dir` to serve()."
+      );
+    }
+    if (rule.action === "proxy") {
+      // Fail loudly at setup instead of on the first matching request.
+      try {
+        new URL(rule.target);
+      } catch {
+        throw new Error(`Rule ${index} ("${match}") has an invalid proxy target: "${rule.target}"`);
+      }
+    }
+
+    const isMatch = picomatch(match, { dot: true });
+    return {
+      match,
+      methods: rule.methods?.map((method) => method.toUpperCase()),
+      action: rule.action,
+      dir,
+      target: rule.action === "proxy" ? rule.target : undefined,
+      isMatch: (urlPath: string) => isMatch(urlPath),
+    };
+  });
+}
+
+/** Find the first rule matching this path and method; undefined means "not ours". */
+export function matchRule(
+  rules: NormalizedRule[],
+  urlPath: string,
+  method: string
+): NormalizedRule | undefined {
+  const upperMethod = method.toUpperCase();
+  return rules.find(
+    (rule) => (!rule.methods || rule.methods.includes(upperMethod)) && rule.isMatch(urlPath)
+  );
+}
+
+/**
+ * Build the proxied URL: the request path (relative to the base URL) and query
+ * string are appended to the target, preserving any path prefix on the target.
+ * "https://api.example.com/v2" + "/users?q=1" -> "https://api.example.com/v2/users?q=1"
+ */
+export function buildProxyTarget(target: string, relativePath: string, search: string): string {
+  const targetUrl = new URL(target);
+  const prefix = targetUrl.pathname.replace(/\/$/, "");
+  targetUrl.pathname = `${prefix}${relativePath}`;
+  targetUrl.search = search;
+  return targetUrl.toString();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chokidar": "^3.6.0",
         "csstree-validator": "^3.0.0",
         "mime-types": "^2.1.35",
+        "picomatch": "^2.3.2",
         "playwright": "^1.62.1",
         "serve-handler": "^6.1.6",
         "yargs": "^17.7.2"
@@ -23,6 +24,7 @@
         "@biomejs/biome": "1.9.4",
         "@types/mime-types": "^2.1.4",
         "@types/node": "^22.10.2",
+        "@types/picomatch": "^4.0.3",
         "@types/serve-handler": "^6.1.4",
         "@types/yargs": "^17.0.33",
         "tsx": "^4.19.4",
@@ -599,6 +601,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
+      "dev": true
+    },
     "node_modules/@types/serve-handler": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.4.tgz",
@@ -1040,9 +1048,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chokidar": "^3.6.0",
     "csstree-validator": "^3.0.0",
     "mime-types": "^2.1.35",
+    "picomatch": "^2.3.2",
     "playwright": "^1.62.1",
     "serve-handler": "^6.1.6",
     "yargs": "^17.7.2"
@@ -52,6 +53,7 @@
     "@biomejs/biome": "1.9.4",
     "@types/mime-types": "^2.1.4",
     "@types/node": "^22.10.2",
+    "@types/picomatch": "^4.0.3",
     "@types/serve-handler": "^6.1.4",
     "@types/yargs": "^17.0.33",
     "tsx": "^4.19.4",

--- a/test/browser/routing.test.ts
+++ b/test/browser/routing.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { after, before, describe, it } from "node:test";
+import { type Browser, type Page, chromium } from "playwright";
+import { createServer } from "../../lib/hrserve";
+
+let browser: Browser;
+/** A real HTTP server standing in for "the network" (upstream / proxy target). */
+let upstream: http.Server;
+let upstreamOrigin: string;
+const upstreamHits: Array<{ method: string; url: string; body: string }> = [];
+
+async function makeFixture(files: Record<string, string>): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "hrserve-routing-"));
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+  }
+  return dir;
+}
+
+before(async () => {
+  browser = await chromium.launch({ headless: true });
+
+  upstream = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString();
+      upstreamHits.push({ method: req.method ?? "", url: req.url ?? "", body });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ from: "upstream", method: req.method, url: req.url, body }));
+    });
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  upstreamOrigin = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
+});
+
+after(async () => {
+  await browser.close();
+  await new Promise<void>((resolve) => upstream.close(() => resolve()));
+});
+
+describe("routing rules", () => {
+  it("serves matched paths locally and lets unmatched ones reach the network", async () => {
+    upstreamHits.length = 0;
+    const dir = await makeFixture({
+      "index.html": "<!DOCTYPE html><html><body><h1>local</h1></body></html>",
+      "app.css": "h1 { color: rgb(1, 2, 3); }",
+    });
+    const server = createServer(browser);
+    let page: Page | undefined;
+    try {
+      // Base URL *is* the real server, so "upstream" requests are really served by it
+      page = await server.serve({
+        url: `${upstreamOrigin}/`,
+        dir,
+        rules: [
+          { match: "/api/**", action: "upstream" },
+          { match: "**", action: "serve" },
+        ],
+      });
+
+      // index.html came from disk, not from the upstream server
+      assert.equal(await page.textContent("h1"), "local");
+
+      const api = await page.evaluate(() => fetch("/api/ping").then((r) => r.json()));
+      assert.equal(api.from, "upstream");
+      assert.deepEqual(
+        upstreamHits.map((hit) => hit.url),
+        ["/api/ping"],
+        "only the /api request should have reached the network"
+      );
+    } finally {
+      await page?.context().close();
+      await server.close();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("proxies matched paths to another origin without CORS", async () => {
+    upstreamHits.length = 0;
+    const dir = await makeFixture({
+      "index.html": "<!DOCTYPE html><html><body><h1>proxy</h1></body></html>",
+    });
+    const server = createServer(browser);
+    let page: Page | undefined;
+    try {
+      page = await server.serve({
+        url: "http://proxy.hrserve.test/",
+        dir,
+        rules: [
+          { match: "/api/**", action: "proxy", target: upstreamOrigin },
+          { match: "**", action: "serve" },
+        ],
+      });
+
+      // The page reads the body of a cross-origin response: only possible because
+      // the browser still considers this a same-origin request.
+      const json = await page.evaluate(() => fetch("/api/users?q=1").then((r) => r.json()));
+      assert.equal(json.from, "upstream");
+      assert.equal(json.url, "/api/users?q=1", "path and query survive the rewrite");
+    } finally {
+      await page?.context().close();
+      await server.close();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("proxies non-GET requests with their body intact", async () => {
+    upstreamHits.length = 0;
+    const dir = await makeFixture({
+      "index.html": "<!DOCTYPE html><html><body><h1>post</h1></body></html>",
+    });
+    const server = createServer(browser);
+    let page: Page | undefined;
+    try {
+      page = await server.serve({
+        url: "http://post.hrserve.test/",
+        dir,
+        rules: [
+          { match: "/api/**", action: "proxy", target: upstreamOrigin },
+          { match: "**", action: "serve" },
+        ],
+      });
+
+      const json = await page.evaluate(() =>
+        fetch("/api/todos", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "write tests" }),
+        }).then((r) => r.json())
+      );
+      assert.equal(json.method, "POST");
+      assert.deepEqual(JSON.parse(json.body), { title: "write tests" });
+    } finally {
+      await page?.context().close();
+      await server.close();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("serves several directories at different mount points", async () => {
+    const site = await makeFixture({
+      "index.html": "<!DOCTYPE html><html><body><h1>site</h1></body></html>",
+    });
+    const ui = await makeFixture({ "ui/button.css": ".btn { color: rgb(4, 5, 6); }" });
+    const server = createServer(browser);
+    let page: Page | undefined;
+    try {
+      page = await server.serve({
+        url: "http://mounts.hrserve.test/",
+        dir: site,
+        rules: [
+          { match: "/ui/**", action: "serve", dir: ui },
+          { match: "**", action: "serve" },
+        ],
+      });
+
+      assert.equal(await page.textContent("h1"), "site");
+      const css = await page.evaluate(() => fetch("/ui/button.css").then((r) => r.text()));
+      assert.match(css, /rgb\(4, 5, 6\)/);
+    } finally {
+      await page?.context().close();
+      await server.close();
+      await fs.rm(site, { recursive: true, force: true });
+      await fs.rm(ui, { recursive: true, force: true });
+    }
+  });
+
+  it("still patches files served through a scoped rule", async () => {
+    const dir = await makeFixture({
+      "index.html":
+        '<!DOCTYPE html><html><head><link rel="stylesheet" href="/static/style.css"></head>' +
+        "<body><h1>scoped</h1></body></html>",
+      "static/style.css": "h1 { color: rgb(255, 0, 0); }",
+    });
+    const server = createServer(browser);
+    let page: Page | undefined;
+    try {
+      page = await server.serve({
+        url: "http://scoped.hrserve.test/",
+        dir,
+        rules: [
+          { match: "/static/**", action: "serve" },
+          { match: "**", action: "serve" },
+        ],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const patched = new Promise((resolve) => server.on("patch", resolve));
+      await fs.writeFile(path.join(dir, "static", "style.css"), "h1 { color: rgb(0, 128, 0); }");
+      await patched;
+
+      const deadline = Date.now() + 10_000;
+      let color = "";
+      while (color !== "rgb(0, 128, 0)" && Date.now() < deadline) {
+        color = await page.evaluate(
+          () => getComputedStyle(document.querySelector("h1") as Element).color
+        );
+        if (color !== "rgb(0, 128, 0)") await new Promise((r) => setTimeout(r, 100));
+      }
+      assert.equal(color, "rgb(0, 128, 0)");
+    } finally {
+      await page?.context().close();
+      await server.close();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/resolve-request.test.ts
+++ b/test/unit/resolve-request.test.ts
@@ -3,7 +3,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { after, before, describe, it } from "node:test";
-import { normalizeBaseUrl, resolveRequest } from "../../lib/resolve-request";
+import { type ResolveConfig, normalizeBaseUrl, resolveRequest } from "../../lib/resolve-request";
+import { type Rule, normalizeRules } from "../../lib/rules";
+
+/** Build the config serve() would build for a given base URL / dir / rules. */
+function config(baseUrl: string, dir?: string, rules?: Rule[]): ResolveConfig {
+  return { baseUrl: normalizeBaseUrl(baseUrl), rules: normalizeRules(rules, dir) };
+}
 
 describe("normalizeBaseUrl", () => {
   it("appends a trailing slash when missing", () => {
@@ -18,6 +24,7 @@ describe("normalizeBaseUrl", () => {
 describe("resolveRequest", () => {
   let dir: string;
   const base = "http://localhost:3000/";
+  let plain: ResolveConfig;
 
   before(async () => {
     dir = await fs.mkdtemp(path.join(os.tmpdir(), "hrserve-resolve-"));
@@ -29,6 +36,7 @@ describe("resolveRequest", () => {
     await fs.writeFile(path.join(dir, "sub", "note.txt"), "note");
     await fs.mkdir(path.join(dir, "app"));
     await fs.writeFile(path.join(dir, "app", "index.html"), "<h1>app</h1>");
+    plain = config(base, dir);
   });
 
   after(async () => {
@@ -36,7 +44,7 @@ describe("resolveRequest", () => {
   });
 
   it("serves index.html for the root URL", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/");
     assert.deepEqual(resolved, {
       kind: "file",
       filePath: path.join(dir, "index.html"),
@@ -45,12 +53,12 @@ describe("resolveRequest", () => {
   });
 
   it("handles a base URL without a trailing slash", async () => {
-    const resolved = await resolveRequest(dir, "http://localhost:3000", "http://localhost:3000/");
+    const resolved = await resolveRequest(config("http://localhost:3000", dir), base);
     assert.equal(resolved.kind, "file");
   });
 
   it("resolves a plain file with its MIME type", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/style.css");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/style.css");
     assert.deepEqual(resolved, {
       kind: "file",
       filePath: path.join(dir, "style.css"),
@@ -59,12 +67,12 @@ describe("resolveRequest", () => {
   });
 
   it("ignores query strings", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/style.css?v=2");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/style.css?v=2");
     assert.equal(resolved.kind, "file");
   });
 
   it("decodes percent-encoded paths", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/with%20space.html");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/with%20space.html");
     assert.deepEqual(resolved, {
       kind: "file",
       filePath: path.join(dir, "with space.html"),
@@ -73,7 +81,7 @@ describe("resolveRequest", () => {
   });
 
   it("serves index.html of a subdirectory that has one", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/app");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/app");
     assert.deepEqual(resolved, {
       kind: "file",
       filePath: path.join(dir, "app", "index.html"),
@@ -82,68 +90,202 @@ describe("resolveRequest", () => {
   });
 
   it("falls back to a listing for a directory without index.html", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/sub/");
-    assert.deepEqual(resolved, { kind: "fallback", urlPath: "/sub/" });
+    const resolved = await resolveRequest(plain, "http://localhost:3000/sub/");
+    assert.deepEqual(resolved, { kind: "fallback", urlPath: "/sub/", dir });
   });
 
   it("falls back for a missing file, preserving the URL path", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/nope.png");
-    assert.deepEqual(resolved, { kind: "fallback", urlPath: "/nope.png" });
+    const resolved = await resolveRequest(plain, "http://localhost:3000/nope.png");
+    assert.deepEqual(resolved, { kind: "fallback", urlPath: "/nope.png", dir });
   });
 
   it("returns unknown-type for existing files without a known extension", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/LICENSE");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/LICENSE");
     assert.equal(resolved.kind, "unknown-type");
   });
 
   it("works with a relative dir (path.join must not corrupt the fallback path)", async () => {
     const relativeDir = path.relative(process.cwd(), dir);
-    const file = await resolveRequest(relativeDir, base, "http://localhost:3000/style.css");
+    const relative = config(base, relativeDir);
+    const file = await resolveRequest(relative, "http://localhost:3000/style.css");
     assert.equal(file.kind, "file");
     assert.equal(
       path.resolve((file as { filePath: string }).filePath),
       path.join(dir, "style.css")
     );
 
-    const missing = await resolveRequest(relativeDir, base, "http://localhost:3000/nope.html");
-    assert.deepEqual(missing, { kind: "fallback", urlPath: "/nope.html" });
+    const missing = await resolveRequest(relative, "http://localhost:3000/nope.html");
+    assert.deepEqual(missing, { kind: "fallback", urlPath: "/nope.html", dir: relativeDir });
   });
 
   it("does not capture other origins that share the base as a string prefix", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:30001/style.css");
+    const resolved = await resolveRequest(plain, "http://localhost:30001/style.css");
     assert.deepEqual(resolved, { kind: "pass" });
   });
 
   it("does not capture sibling paths that share the base path as a string prefix", async () => {
-    const resolved = await resolveRequest(dir, "http://host/app", "http://host/apple/style.css");
+    const resolved = await resolveRequest(
+      config("http://host/app", dir),
+      "http://host/apple/style.css"
+    );
     assert.deepEqual(resolved, { kind: "pass" });
   });
 
   it("passes through unrelated origins", async () => {
-    const resolved = await resolveRequest(dir, base, "https://example.com/style.css");
+    const resolved = await resolveRequest(plain, "https://example.com/style.css");
     assert.deepEqual(resolved, { kind: "pass" });
   });
 
   it("rejects traversal via percent-encoded slashes", async () => {
     const resolved = await resolveRequest(
-      dir,
-      base,
+      plain,
       "http://localhost:3000/x%2f..%2f..%2f..%2fetc%2fpasswd"
     );
     assert.deepEqual(resolved, { kind: "forbidden" });
   });
 
   it("rejects malformed percent-encoding", async () => {
-    const resolved = await resolveRequest(dir, base, "http://localhost:3000/%zz");
+    const resolved = await resolveRequest(plain, "http://localhost:3000/%zz");
     assert.deepEqual(resolved, { kind: "forbidden" });
   });
 
   it("resolves paths under a base URL with a subpath", async () => {
-    const resolved = await resolveRequest(dir, "http://host/app/", "http://host/app/style.css");
+    const resolved = await resolveRequest(
+      config("http://host/app/", dir),
+      "http://host/app/style.css"
+    );
     assert.deepEqual(resolved, {
       kind: "file",
       filePath: path.join(dir, "style.css"),
       mimeType: "text/css",
     });
+  });
+
+  it("passes non-GET methods through to the network when serving files", async () => {
+    const resolved = await resolveRequest(plain, "http://localhost:3000/style.css", "POST");
+    assert.deepEqual(resolved, { kind: "pass" });
+  });
+
+  describe("routing rules", () => {
+    it("serves only paths matched by a serve rule", async () => {
+      const scoped = config(base, dir, [{ match: "/sub/**", action: "serve" }]);
+      assert.equal(
+        (await resolveRequest(scoped, "http://localhost:3000/sub/note.txt")).kind,
+        "file"
+      );
+      // outside the rule: not ours, goes to the network
+      assert.deepEqual(await resolveRequest(scoped, "http://localhost:3000/style.css"), {
+        kind: "pass",
+      });
+    });
+
+    it("applies the first matching rule", async () => {
+      const ordered = config(base, dir, [
+        { match: "/api/**", action: "upstream" },
+        { match: "**", action: "serve" },
+      ]);
+      assert.deepEqual(await resolveRequest(ordered, "http://localhost:3000/api/users"), {
+        kind: "pass",
+      });
+      assert.equal((await resolveRequest(ordered, "http://localhost:3000/style.css")).kind, "file");
+    });
+
+    it("serves different directories from different rules", async () => {
+      const other = await fs.mkdtemp(path.join(os.tmpdir(), "hrserve-alt-"));
+      await fs.writeFile(path.join(other, "alt.css"), "h1 {}");
+      try {
+        const mounted = config(base, dir, [
+          { match: "/ui/**", action: "serve", dir: other },
+          { match: "**", action: "serve" },
+        ]);
+        // Rule dirs mirror the URL space below the mount, so /ui/alt.css -> <other>/ui/alt.css
+        assert.deepEqual(await resolveRequest(mounted, "http://localhost:3000/ui/alt.css"), {
+          kind: "fallback",
+          urlPath: "/ui/alt.css",
+          dir: other,
+        });
+        assert.equal(
+          (await resolveRequest(mounted, "http://localhost:3000/style.css")).kind,
+          "file"
+        );
+      } finally {
+        await fs.rm(other, { recursive: true, force: true });
+      }
+    });
+
+    it("rewrites proxied requests onto the target origin, keeping path and query", async () => {
+      const proxied = config(base, dir, [
+        { match: "/api/**", action: "proxy", target: "https://staging.example.com" },
+      ]);
+      assert.deepEqual(await resolveRequest(proxied, "http://localhost:3000/api/users?q=1"), {
+        kind: "proxy",
+        target: "https://staging.example.com/api/users?q=1",
+      });
+    });
+
+    it("preserves a path prefix on the proxy target", async () => {
+      const proxied = config(base, dir, [
+        { match: "/api/**", action: "proxy", target: "https://example.com/v2/" },
+      ]);
+      assert.deepEqual(await resolveRequest(proxied, "http://localhost:3000/api/users"), {
+        kind: "proxy",
+        target: "https://example.com/v2/api/users",
+      });
+    });
+
+    it("proxies every method, not just GET", async () => {
+      const proxied = config(base, dir, [
+        { match: "/api/**", action: "proxy", target: "https://example.com" },
+      ]);
+      const resolved = await resolveRequest(proxied, "http://localhost:3000/api/users", "POST");
+      assert.equal(resolved.kind, "proxy");
+    });
+
+    it("honours method-scoped rules", async () => {
+      const byMethod = config(base, dir, [
+        { match: "/api/**", methods: ["post"], action: "proxy", target: "https://example.com" },
+        { match: "**", action: "serve" },
+      ]);
+      assert.equal(
+        (await resolveRequest(byMethod, "http://localhost:3000/api/x", "POST")).kind,
+        "proxy"
+      );
+      // GET falls through to the serve rule
+      assert.equal(
+        (await resolveRequest(byMethod, "http://localhost:3000/api/x", "GET")).kind,
+        "fallback"
+      );
+    });
+  });
+});
+
+describe("normalizeRules", () => {
+  it("defaults to serving everything from the top-level dir", () => {
+    const rules = normalizeRules(undefined, "/tmp/site");
+    assert.equal(rules.length, 1);
+    assert.equal(rules[0].action, "serve");
+    assert.equal(rules[0].match, "**");
+    assert.equal(rules[0].dir, "/tmp/site");
+  });
+
+  it("inherits the top-level dir for serve rules that omit it", () => {
+    const rules = normalizeRules([{ match: "/a/**", action: "serve" }], "/tmp/site");
+    assert.equal(rules[0].dir, "/tmp/site");
+  });
+
+  it("throws when a serve rule has no directory anywhere", () => {
+    assert.throws(() => normalizeRules([{ match: "/a/**", action: "serve" }]), /no directory/);
+  });
+
+  it("throws on an invalid proxy target", () => {
+    assert.throws(
+      () => normalizeRules([{ match: "**", action: "proxy", target: "not-a-url" }]),
+      /invalid proxy target/
+    );
+  });
+
+  it("does not require a dir when no serve rule is present", () => {
+    const rules = normalizeRules([{ match: "**", action: "upstream" }]);
+    assert.equal(rules[0].action, "upstream");
   });
 });


### PR DESCRIPTION
First of three stacked PRs implementing the routing/mocking/agent features from `POSSIBLE_EXTRA_FEATURES.md` (A1 → A2 → C).

## What

Serving was all-or-nothing: every `GET` under the base URL came from one directory. This adds an ordered rule table — first match wins — matched against the request path **relative to the base URL**:

```js
await server.serve({
  url: "https://app.example.com/",
  dir: "./dist",
  rules: [
    { match: "/assets/**", action: "serve", dir: "./dist/assets" },
    { match: "/api/**", action: "proxy", target: "https://staging-api.example.com" },
    { match: "/health", action: "upstream" },
    { match: "**", action: "serve" },
  ],
});
```

| Action | Behaviour |
|---|---|
| `serve` | Answer from a directory (per-rule `dir`, defaulting to the top-level one) — this also gives **multiple mount points** for free. `GET`/`HEAD` only; other methods go to the network. Served files are still watched and patched. |
| `upstream` | Let the request through to the real network, untouched. |
| `proxy` | Send it to another origin, preserving path, query, method, headers and body. Unreachable target → 502. |

Rules take an optional `methods: ["POST"]` filter. Requests matching **no** rule go to the network, so a rule list without a `**` entry is an overlay rather than a full server. Passing no `rules` behaves exactly as before.

## Implementation note worth reviewing

**Proxying uses `route.fetch()` + `route.fulfill()`, not `route.continue({ url })`.** I tried the obvious `continue({ url })` first: Playwright accepts it without complaint, but the browser then treats the response as cross-origin, applies CORS, and the page gets `TypeError: Failed to fetch` (reproduced in isolation before changing the approach). Fetching from Node and fulfilling locally means the page still sees a same-origin response — which is what makes "mock/proxy your API without CORS" actually work. This is recorded in AGENTS.md so it doesn't get "simplified" back later.

`picomatch` (already present transitively via chokidar) is now a direct dependency for glob matching.

## Test plan

- **+13 unit tests**: rule ordering/first-match, per-rule dirs, method filters, proxy URL construction incl. target path prefixes and query preservation, normalization errors (serve rule with no dir, invalid proxy target). Existing resolve-request tests updated for the new config shape and still cover every prior routing regression.
- **+5 browser tests** (`test/browser/routing.test.ts`) against a **real local HTTP server** standing in for the network: local-vs-upstream split (asserting only the `/api` request actually left), cross-origin proxy read from the page (proves no CORS), `POST` with body through the proxy, two mount points, and patching still working through a scoped rule.
- Full suite: 35 unit + 12 browser, lint and tsc clean.