### PR TITLE
feat: start agent sessions from saved profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ import { SessionManager } from "hrserve/dist/lib/session-manager.js";
 const manager = new SessionManager({ browser });
 await manager.start({ name: "feature-a", dir: "~/wt/feature-a" });
 await manager.start({ name: "feature-b", dir: "~/wt/feature-b" }); // same URL, no conflict
+
+// Sign in once, then start every worktree's session already authenticated
+await manager.start({ name: "feature-c", dir: "~/wt/feature-c", profile: "app-login" });
+await manager.get("feature-c").saveProfile("app-login-with-cart"); // snapshot, never overwrites
 ```
 
 Each session buffers its own console output, request log and patch history.
@@ -211,7 +215,8 @@ Register it with an MCP-capable agent and it can serve a worktree and then *veri
 
 | Tool | What it answers |
 |---|---|
-| `serve_start` / `serve_list` / `serve_stop` | session lifecycle, one per worktree |
+| `serve_start` / `serve_list` / `serve_stop` | session lifecycle, one per worktree (pass `profile` to start signed in) |
+| `profile_list` / `profile_save` | reuse a sign-in across sessions — see [Session profiles](#session-profiles) |
 | `page_screenshot` | "what does it look like now?" |
 | `page_console` | "did my change break anything?" (console + uncaught errors) |
 | `page_network` | "why did that request return that?" — each entry labelled `served-local`, `mocked`, `proxied`, `upstream` or `blocked` |

--- a/lib/mcp-server.ts
+++ b/lib/mcp-server.ts
@@ -57,6 +57,7 @@ function withSession<T>(
 
 export function createMcpServer(manager: SessionManager): McpServer {
   const server = new McpServer({ name: "hrserve", version: VERSION });
+  const profiles = manager.profiles;
 
   server.registerTool(
     "serve_start",
@@ -75,6 +76,13 @@ export function createMcpServer(manager: SessionManager): McpServer {
         mockDir: z.string().optional().describe("Directory of file-based mock API routes"),
         mockPath: z.string().optional().describe("Path glob for mocks/proxy (default /api/**)"),
         proxy: z.string().optional().describe("Origin for requests no mock route answers"),
+        profile: z
+          .string()
+          .optional()
+          .describe(
+            "Saved profile to start from, so the session begins already signed in. " +
+              "Omit for a completely fresh session."
+          ),
         width: z.number().optional(),
         height: z.number().optional(),
       },
@@ -113,6 +121,40 @@ export function createMcpServer(manager: SessionManager): McpServer {
         return failure(error);
       }
     }
+  );
+
+  server.registerTool(
+    "profile_list",
+    {
+      title: "List saved profiles",
+      description:
+        "Saved authentication profiles a session can start from, with the origins each covers, " +
+        "when it was captured and which profile it branched from.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        return text(await profiles.list());
+      } catch (error) {
+        return failure(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "profile_save",
+    {
+      title: "Save a session as a profile",
+      description:
+        "Snapshot a session's current cookies and storage under a new profile name, so a " +
+        "sign-in or captcha done once can be reused. Profiles are immutable: this always " +
+        "writes a new name and never modifies the one the session started from.",
+      inputSchema: {
+        name: nameArg,
+        as: z.string().describe("Name for the new profile"),
+      },
+    },
+    async ({ name, as }) => withSession(manager, name, (session) => session.saveProfile(as))
   );
 
   server.registerTool(

--- a/lib/session-manager.ts
+++ b/lib/session-manager.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import type { Browser, BrowserContext, ConsoleMessage, Page } from "playwright";
-import { type PatchOutcome, type RequestEvent, createServer } from "./hrserve";
+import {
+  type PatchOutcome,
+  ProfileStore,
+  type ProfileSummary,
+  type RequestEvent,
+  createServer,
+} from "./hrserve";
 import type { Rule } from "./rules";
 
 /**
@@ -28,6 +34,12 @@ export interface StartSessionOptions {
   mockPath?: string;
   /** Convenience: proxy `mockPath` requests that no mock route answers. */
   proxy?: string;
+  /**
+   * Saved profile to start from, so a session begins already logged in
+   * instead of repeating a manual sign-in. The session never writes back
+   * to it — call `session.saveProfile()` to snapshot the result.
+   */
+  profile?: string;
   width?: number;
   height?: number;
 }
@@ -57,6 +69,8 @@ export interface SessionInfo {
   name: string;
   url: string;
   dir: string;
+  /** Profile this session started from, if any. */
+  profile?: string;
   createdAt: number;
   patches: number;
   /** Console errors + uncaught page exceptions seen so far. */
@@ -95,6 +109,7 @@ export class Session {
   readonly name: string;
   readonly url: string;
   readonly dir: string;
+  readonly profile?: string;
   readonly createdAt = Date.now();
   readonly console: ConsoleEntry[];
   readonly network: NetworkEntry[];
@@ -107,11 +122,13 @@ export class Session {
     readonly page: Page,
     readonly context: BrowserContext,
     private readonly server: ReturnType<typeof createServer>,
-    buffers: SessionBuffers
+    buffers: SessionBuffers,
+    profile?: string
   ) {
     this.name = name;
     this.url = url;
     this.dir = dir;
+    this.profile = profile;
     this.console = buffers.console;
     this.network = buffers.network;
     this.patches = buffers.patches;
@@ -122,10 +139,21 @@ export class Session {
       name: this.name,
       url: this.url,
       dir: this.dir,
+      profile: this.profile,
       createdAt: this.createdAt,
       patches: this.patches.length,
       errors: this.console.filter((entry) => entry.type === "error").length,
     };
+  }
+
+  /**
+   * Snapshot this session's cookies and storage under a new profile name, so
+   * work done here (a sign-in, a captcha) can be reused by later sessions.
+   * The profile this session started from is left untouched and recorded as
+   * the new snapshot's parent.
+   */
+  saveProfile(name: string): Promise<ProfileSummary> {
+    return this.server.saveProfile(name);
   }
 
   /** Wait for the next patch — lets an agent await "my edit landed" rather than poll. */
@@ -152,12 +180,18 @@ export class Session {
 
 export interface SessionManagerOptions {
   browser: Browser;
+  /** Where named profiles are stored. Defaults to the per-user data directory. */
+  profilesDir?: string;
 }
 
 export class SessionManager {
   private readonly sessions = new Map<string, Session>();
+  /** The profiles sessions here can start from, in the same directory they save to. */
+  readonly profiles: ProfileStore;
 
-  constructor(private readonly options: SessionManagerOptions) {}
+  constructor(private readonly options: SessionManagerOptions) {
+    this.profiles = new ProfileStore(options.profilesDir);
+  }
 
   list(): SessionInfo[] {
     return [...this.sessions.values()].map((session) => session.info);
@@ -185,7 +219,7 @@ export class SessionManager {
     const rules = options.rules ?? buildRules(options);
 
     const buffers: SessionBuffers = { console: [], network: [], patches: [] };
-    const server = createServer(this.options.browser);
+    const server = createServer(this.options.browser, { profilesDir: this.options.profilesDir });
 
     // Subscribe before serving: the initial navigation already produces
     // requests and console output, and an agent asking "what happened on load?"
@@ -212,6 +246,7 @@ export class SessionManager {
       url,
       dir,
       rules,
+      profile: options.profile,
       width: options.width,
       height: options.height,
       onPage: (page) => {
@@ -234,7 +269,16 @@ export class SessionManager {
       },
     });
 
-    const session = new Session(options.name, url, dir, page, page.context(), server, buffers);
+    const session = new Session(
+      options.name,
+      url,
+      dir,
+      page,
+      page.context(),
+      server,
+      buffers,
+      options.profile
+    );
     this.sessions.set(options.name, session);
     return session.info;
   }

--- a/test/browser/mcp.test.ts
+++ b/test/browser/mcp.test.ts
@@ -78,6 +78,8 @@ describe("MCP server", () => {
       "page_reload",
       "page_screenshot",
       "patch_history",
+      "profile_list",
+      "profile_save",
       "serve_list",
       "serve_start",
       "serve_stop",

--- a/test/browser/session-profiles.test.ts
+++ b/test/browser/session-profiles.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, before, describe, it } from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { type Browser, chromium } from "playwright";
+import { createMcpServer } from "../../lib/mcp-server";
+import { SessionManager } from "../../lib/session-manager";
+
+let browser: Browser;
+let manager: SessionManager;
+let client: Client;
+let profilesDir: string;
+let siteDir: string;
+
+interface ToolContent {
+  type: string;
+  text?: string;
+}
+
+async function callTool(name: string, args: Record<string, unknown> = {}) {
+  return (await client.callTool({ name, arguments: args })) as {
+    isError?: boolean;
+    content: ToolContent[];
+  };
+}
+
+const textOf = (result: { content: ToolContent[] }) =>
+  result.content.map((entry) => entry.text ?? "").join("\n");
+const jsonOf = (result: { content: ToolContent[] }) => JSON.parse(textOf(result));
+
+const readToken = () => window.localStorage.getItem("token");
+
+before(async () => {
+  browser = await chromium.launch({ headless: true });
+  profilesDir = await fs.mkdtemp(path.join(os.tmpdir(), "hrserve-sessprof-"));
+  siteDir = await fs.mkdtemp(path.join(os.tmpdir(), "hrserve-sessprofsite-"));
+  await fs.writeFile(
+    path.join(siteDir, "index.html"),
+    "<!DOCTYPE html><html><body><h1>app</h1></body></html>"
+  );
+
+  manager = new SessionManager({ browser, profilesDir });
+  const server = createMcpServer(manager);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: "test-agent", version: "1.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+});
+
+after(async () => {
+  await client.close();
+  await manager.closeAll();
+  await browser.close();
+  await fs.rm(profilesDir, { recursive: true, force: true });
+  await fs.rm(siteDir, { recursive: true, force: true });
+});
+
+describe("sessions starting from profiles", () => {
+  it("saves a session's state and starts later sessions already signed in", async () => {
+    // The manual step an agent cannot do for itself, done once
+    await manager.start({ name: "signin", dir: siteDir });
+    const signin = manager.get("signin");
+    assert.equal(signin.info.profile, undefined, "a fresh session reports no profile");
+    await signin.page.evaluate(() => window.localStorage.setItem("token", "signed-in"));
+
+    const saved = await signin.saveProfile("agent-login");
+    assert.equal(saved.name, "agent-login");
+    assert.equal(saved.parent, undefined);
+    await manager.stop("signin");
+
+    // Every later session starts from it, without repeating the sign-in
+    const info = await manager.start({
+      name: "worker",
+      dir: siteDir,
+      profile: "agent-login",
+    });
+    assert.equal(info.profile, "agent-login", "the session reports what it started from");
+    assert.equal(await manager.get("worker").page.evaluate(readToken), "signed-in");
+    await manager.stop("worker");
+  });
+
+  it("keeps parallel sessions from one profile independent", async () => {
+    await manager.start({ name: "wt-a", dir: siteDir, profile: "agent-login" });
+    await manager.start({ name: "wt-b", dir: siteDir, profile: "agent-login" });
+    try {
+      const a = manager.get("wt-a");
+      const b = manager.get("wt-b");
+      assert.equal(await a.page.evaluate(readToken), "signed-in");
+      assert.equal(await b.page.evaluate(readToken), "signed-in");
+
+      // One worktree's session changing state must not leak into the other
+      await a.page.evaluate(() => window.localStorage.setItem("scratch", "only-a"));
+      assert.equal(
+        await b.page.evaluate(() => window.localStorage.getItem("scratch")),
+        null,
+        "sessions from the same profile stay isolated"
+      );
+    } finally {
+      await manager.stop("wt-a");
+      await manager.stop("wt-b");
+    }
+  });
+
+  it("records lineage when a session is saved as a new profile", async () => {
+    await manager.start({ name: "extra", dir: siteDir, profile: "agent-login" });
+    try {
+      const session = manager.get("extra");
+      await session.page.evaluate(() => window.localStorage.setItem("mfa", "done"));
+      const saved = await session.saveProfile("agent-login-mfa");
+      assert.equal(saved.parent, "agent-login", "the profile it started from is the parent");
+    } finally {
+      await manager.stop("extra");
+    }
+
+    // The original profile is untouched, so it stays reproducible
+    await manager.start({ name: "check", dir: siteDir, profile: "agent-login" });
+    try {
+      assert.equal(
+        await manager.get("check").page.evaluate(() => window.localStorage.getItem("mfa")),
+        null
+      );
+    } finally {
+      await manager.stop("check");
+    }
+  });
+
+  it("exposes profiles to agents over MCP", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((tool) => tool.name);
+    assert.ok(names.includes("profile_list"));
+    assert.ok(names.includes("profile_save"));
+
+    const listed = jsonOf(await callTool("profile_list")) as Array<{
+      name: string;
+      parent?: string;
+    }>;
+    assert.deepEqual(listed.map((profile) => profile.name).sort(), [
+      "agent-login",
+      "agent-login-mfa",
+    ]);
+    assert.equal(listed.find((p) => p.name === "agent-login-mfa")?.parent, "agent-login");
+
+    // An agent can start from a profile and snapshot its own result
+    const started = jsonOf(
+      await callTool("serve_start", {
+        name: "mcp-session",
+        dir: siteDir,
+        profile: "agent-login",
+      })
+    ) as { profile?: string };
+    assert.equal(started.profile, "agent-login");
+
+    // page_eval returns string results as plain text, not JSON
+    const token = textOf(
+      await callTool("page_eval", {
+        name: "mcp-session",
+        expression: "window.localStorage.getItem('token')",
+      })
+    );
+    assert.equal(token, "signed-in");
+
+    const saved = jsonOf(
+      await callTool("profile_save", { name: "mcp-session", as: "from-mcp" })
+    ) as {
+      name: string;
+      parent?: string;
+    };
+    assert.equal(saved.name, "from-mcp");
+    assert.equal(saved.parent, "agent-login");
+
+    await callTool("serve_stop", { name: "mcp-session" });
+  });
+
+  it("reports a clear error when the profile does not exist", async () => {
+    const result = await callTool("serve_start", {
+      name: "ghost-session",
+      dir: siteDir,
+      profile: "no-such-profile",
+    });
+    assert.equal(result.isError, true);
+    assert.match(textOf(result), /No profile named "no-such-profile"/);
+    // ...and the failed session is not left registered
+    assert.ok(!manager.list().some((session) => session.name === "ghost-session"));
+  });
+});


### PR DESCRIPTION
The follow-up flagged in #37. Profiles (#36) and the session/MCP layer (#35) were developed in parallel and landed separately, so they couldn't be used together.

## Why this was a real gap

An agent could serve a worktree and inspect the page, but any site behind a sign-in was only reachable by repeating the login in every session — and a captcha it can't solve at all. Profiles already solved that for the CLI; sessions just had no way to reach them.

```js
// sign in by hand once (headed), snapshot it
await manager.get("signin").saveProfile("app-login");

// every worktree's session then starts already authenticated
await manager.start({ name: "feature-a", dir: "~/wt/a", profile: "app-login" });
await manager.start({ name: "feature-b", dir: "~/wt/b", profile: "app-login" });
```

## What's added

- `StartSessionOptions.profile` and `SessionManagerOptions.profilesDir`
- `session.saveProfile(name)`; `SessionInfo.profile` reports what a session started from
- `SessionManager.profiles` exposes the store
- MCP: `serve_start` gains a `profile` argument, plus **`profile_list`** (what's available, with lineage) and **`profile_save`** (snapshot this session under a new name)

The immutability rule carries over untouched: sessions never write back to the profile they started from, so several worktrees can run from one profile at once and saving always creates a new name with the original recorded as parent.

## Test plan

**+5 browser tests** covering the actual agent workflow: save state from a fresh session and start a later one already signed in; two parallel sessions from the same profile that stay isolated (one setting state the other can't see); lineage recorded on save with the parent profile verified unchanged afterwards; the full MCP path (`profile_list` → `serve_start` with a profile → `page_eval` confirming restored state → `profile_save`); and a clear error for an unknown profile, asserting the failed session isn't left registered.

Also updated the tool-inventory assertion in `mcp.test.ts` — it pins the exact tool list, so adding two tools correctly failed it.

Full suite: 85 unit + 44 browser, lint and tsc clean.