### PR TITLE
fix: stop biome and release-please fighting over package.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -48,5 +48,11 @@
       "indentStyle": "space",
       "indentWidth": 2
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": ["package.json", "package-lock.json"],
+      "formatter": { "enabled": false }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
     "live module updating",
     "live module reloading"
   ],
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/mime-types": "^2.1.4",


### PR DESCRIPTION
## Problem

`biome check .` has been failing on every build since the 1.2.0 release merge — on `main` and on the release PR #43.

The two tools disagree about how to serialize `package.json`:

- **Biome's formatter** collapses `"files": ["dist"]` onto one line (it fits within `lineWidth: 100`).
- **release-please** rewrites the whole file through its own JSON serializer when it bumps the version, which always expands arrays.

cae0128 (the 1.2.0 release merge) shows it exactly — alongside the version bump it re-expanded `files`:

```diff
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
```

Lint is the first CI step, so build and tests never ran on #43. Left alone, this breaks every future release PR too.

## Fix

1. Restore the collapsed `"files": ["dist"]` so lint passes now.
2. Add a Biome override disabling the **formatter** (not the linter) for `package.json` and `package-lock.json`, so release-please's serialization no longer fails CI. Linting of other JSON is unaffected.

Verified by re-serializing `package.json` the way release-please does — `biome check .` still exits 0 with the array expanded.

## Verification

- `npm run lint` — exits 0 (7 pre-existing warnings remain; they are configured as warnings and do not fail the build)
- `npm run build` — clean
- `npm run test:unit` — 99/99 pass
- `npm run test:browser` — 51/51 pass

Once this merges, the next release-please run regenerates #43's branch with the fix included.

## Out of scope

The 7 remaining warnings (`noUnusedVariables` in `lib/reload-image.ts`, `useTemplate` in `lib/hrserve.ts:321` and `lib/session-manager.ts:205`) are untouched — they did not contribute to the failure. Worth a separate cleanup.